### PR TITLE
Added a config option for quality with HD as default

### DIFF
--- a/gbDowloader.go
+++ b/gbDowloader.go
@@ -72,7 +72,7 @@ func getInitialConfig() {
 	pflag.Int("offset", offsetDefault, "Start from further back in history. E.g. --offset=100 will skip the most recent 100 videos and grab the next 100.")
 	pflag.String("filter", "", "API filter to use. E.g. --filter=video_show:39")
 	pflag.Int("retries", retryDefault, "Number of times to retry the API")
-	pflag.String("quality", "", "Video quality to request. E.g. --quality=2 for HD, 1 for High and 0 for Low")
+	pflag.Int("quality", qualityDefault, "Video quality to request. E.g. --quality=2 for HD, 1 for High and 0 for Low")
 	pflag.Parse()
 	viper.BindPFlags(pflag.CommandLine)
 


### PR DESCRIPTION
This is a suggestion for a quality option for those of us with limited harddrive space/network bandwidth.

I made sure the default is still HD.
The numbering is (0:Low, 1:High, 2:HD) and I hope it makes sense in the way that the higher the number gets the better the quality is.
Otherwise feel free to reverse the order if you prefer that.